### PR TITLE
Fix broken code-blocks

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -105,17 +105,23 @@ function convertMarkdownToHtml(filename) {
       html: true,
       breaks: breaks,
       highlight: function (str, lang) {
-        if (lang && hljs.getLanguage(lang)) {
+        if (lang && hljs.getLanguage(lang))
+        {
           try {
-            return '<pre class="hljs"><code>' +
-                hljs.highlight(lang, str, true).value +
-                '</code></pre>';
+            str = hljs.highlight(lang, str, true).value;
           } catch (e) {
+            str = md.utils.escapeHtml(str);
+
             vscode.window.showErrorMessage('ERROR: markdown-it:highlight');
             vscode.window.showErrorMessage(e.message);
           }
         }
-        return '<pre class="hljs"><code>' + md.utils.escapeHtml(str) + '</code></pre>';
+        else
+        {
+          str = md.utils.excapeHtml(str);
+        }
+        
+        return '<pre class="hljs"><code><div>' + str + '</div></code></pre>';
       }
     });
   } catch (e) {

--- a/styles/markdown.css
+++ b/styles/markdown.css
@@ -6,8 +6,9 @@
 body {
 	font-family: "Segoe WPC", "Segoe UI", "SFUIText-Light", "HelveticaNeue-Light", sans-serif, "Droid Sans Fallback";
 	font-size: 14px;
-	padding-left: 12px;
+	padding: 0 12px;
 	line-height: 22px;
+	word-wrap: break-word;
 }
 
 img {
@@ -43,6 +44,16 @@ h1 {
 
 h1, h2, h3 {
 	font-weight: normal;
+}
+
+h1 code,
+h2 code,
+h3 code,
+h4 code,
+h5 code,
+h6 code {
+	font-size: inherit;
+	line-height: auto;
 }
 
 a:hover {
@@ -87,7 +98,8 @@ code {
 	line-height: 18px;
 }
 
-code > div {
+pre:not(.hljs),
+pre.hljs code > div {
 	padding: 16px;
 	border-radius: 3px;
 	overflow: auto;
@@ -95,15 +107,18 @@ code > div {
 
 /** Theming */
 
-.vscode-light {
+.vscode-light,
+.vscode-light pre code {
 	color: rgb(30, 30, 30);
 }
 
-.vscode-dark {
+.vscode-dark,
+.vscode-dark pre code {
 	color: #DDD;
 }
 
-.vscode-high-contrast {
+.vscode-high-contrast,
+.vscode-high-contrast pre code {
 	color: white;
 }
 
@@ -115,14 +130,17 @@ code > div {
 	color: #D7BA7D;
 }
 
+.vscode-light pre:not(.hljs),
 .vscode-light code > div {
 	background-color: rgba(220, 220, 220, 0.4);
 }
 
+.vscode-dark pre:not(.hljs),
 .vscode-dark code > div {
 	background-color: rgba(10, 10, 10, 0.4);
 }
 
+.vscode-high-contrast pre:not(.hljs),
 .vscode-high-contrast code > div {
 	background-color: rgb(0, 0, 0);
 }


### PR DESCRIPTION
Codeblock have an incorrect padding.

For example this here:
```markdown
> **This is a blockquote**  
> ...with some code in it
> ```csharp
> Console.WriteLine("Hello World");
> ```
```
Renders like this.

![image](https://cloud.githubusercontent.com/assets/7085564/24499957/d8769b74-1543-11e7-92cc-51e97db33a43.png)

As you can see the code-block is sticking on the bottom of the box which looks pretty weird.
This can be fixed by wrapping the code with a `<div>`-tag.

Additionally I updated the `markdown.css` to the newest version.