### PR TITLE
markdown-pdf.outputDirectory to accept ${workspaceRoot}

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -353,6 +353,11 @@ function isExistsDir(dirname) {
 
 function getOutputDir(filename) {
   var output_dir = vscode.workspace.getConfiguration('markdown-pdf')['outputDirectory'] || '';
+  if(output_dir.includes('${workspaceRoot}')){
+    var resource = vscode.window.activeTextEditor.document.uri;
+    var fsPath = vscode.workspace.getWorkspaceFolder(resource).uri.fsPath;
+    output_dir = output_dir.replace('${workspaceRoot}', fsPath);
+  }  
   if (output_dir.length !== 0) {
     if (isExistsDir(output_dir)) {
       return path.join(output_dir, path.basename(filename));


### PR DESCRIPTION
I didn't want to enter an absolute path in the markdown-pdf.outputDirectory config, and wanted it always relative to the workspace, so have changed the option to accept ${workspaceRoot} variable.

e.g. {"markdown-pdf.outputDirectory": "${workspaceRoot}/docs/"}

Maybe it would be better to allow relative to original file as well - which might help more people.