### PR TITLE
Fix inline code not being monospaced (Fix #26)

### DIFF
--- a/styles/markdown-pdf.css
+++ b/styles/markdown-pdf.css
@@ -27,7 +27,6 @@ blockquote {
 
 /* for inline code */
 :not(pre):not(.hljs) > code {
-	color: #A31515;
+	color: #C9AE75; /* Change the old color so it seems less like an error */
 	font-size: inherit;
-	font-family: inherit;
 }


### PR DESCRIPTION
Fixes #26 .

Also changes the color of the font to match the default preview color on the default theme of VSCode, while also not seeming so much like an error.