### PR TITLE
Allow online CSS in #67

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -563,7 +563,7 @@ function readStyles() {
         var href = filename = styles[i];
         var protocol = url.parse(href).protocol;
         if (protocol === 'http:' || protocol === 'https:') {
-          style += '<link rel=\"stylesheet\" href=\"" + href + "\" type=\"text/css\">';
+          style += '<link rel=\"stylesheet\" href=\"' + href + '\" type=\"text/css\">';
         } else if (protocol === 'file:') {
           style += makeCss(filename);
         }
@@ -595,15 +595,22 @@ function readStyles() {
   styles = vscode.workspace.getConfiguration('markdown-pdf')['styles'] || '';
   if (styles && Array.isArray(styles) && styles.length > 0) {
     for (i = 0; i < styles.length; i++) {
-      filename = styles[i];
+      var href = filename = styles[i];
+      var protocol = url.parse(href).protocol;
       if (!path.isAbsolute(filename)) {
-        if (vscode.workspace.rootPath == undefined) {
-          filename = path.join(path.dirname(mdfilename), filename);
+        if (protocol === 'http:' || protocol === 'https:') {
+          style += '<link rel=\"stylesheet\" href=\"' + href + '\" type=\"text/css\">';
         } else {
-          filename = path.join(vscode.workspace.rootPath, filename);         
+          if (vscode.workspace.rootPath == undefined) {
+            filename = path.join(path.dirname(mdfilename), filename);
+          } else {
+            filename = path.join(vscode.workspace.rootPath, filename);         
+          }
+          style += makeCss(filename);
         }
+      } else {
+        style += makeCss(filename);
       }
-      style += makeCss(filename);
     }
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -641,7 +641,7 @@
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
       "dev": true,
       "requires": {


### PR DESCRIPTION
Fixes a bug for generating `<link>` tags from external resources and adds the option to load online (http, https) CSS via `markdown-pdf.styles`.