### PR TITLE
Option to specify the plantuml delimiter

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -260,7 +260,11 @@ function convertMarkdownToHtml(filename, type, text) {
 
   // PlantUML
   // https://github.com/gmunguia/markdown-it-plantuml
-  md.use(require('markdown-it-plantuml'));
+  var plantumlOptions = {
+    openMarker: vscode.workspace.getConfiguration('markdown-pdf')['plantumlOpenMarker'] || '@startuml',
+    closeMarker: vscode.workspace.getConfiguration('markdown-pdf')['plantumlCloseMarker'] || '@enduml'
+  }
+  md.use(require('markdown-it-plantuml'), plantumlOptions);
 
   statusbarmessage.dispose();
   return md.render(text);

--- a/package.json
+++ b/package.json
@@ -338,6 +338,20 @@
           "default": "",
           "description": "pdf only. Paper ranges to print, e.g., '1-5, 8, 11-13'."
         },
+        "markdown-pdf.plantumlOpenMarker": {
+          "type": [
+            "string"
+          ],
+          "default": "@startuml",
+          "description": "Oppening delimiter used for the plantuml parser."
+        },
+        "markdown-pdf.plantumlCloseMarker": {
+          "type": [
+            "string"
+          ],
+          "default": "@enduml",
+          "description": "Closing delimiter used for the plantuml parser."
+        },
         "markdown-pdf.format": {
           "type": [
             "string",


### PR DESCRIPTION
I created this pull request to solve the problem from issue #92.

The export of gitlab flavored markdown file with plantuml drawings work fine, if the opening delimiter is set to _\`\`\`plantuml_ and the closing delimiter is set to _\`\`\`_.