### PR TITLE
respect current workspace relative path

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -521,43 +521,34 @@ function deleteFile (path) {
 
 function getOutputDir(filename, resource) {
   try {
-    var outputDir;
     if (resource === undefined) {
       return filename;
     }
-    var outputDirectory = vscode.workspace.getConfiguration('markdown-pdf')['outputDirectory'] || '';
-    if (outputDirectory.length === 0) {
+
+    const outputDirectory = vscode.workspace.getConfiguration('markdown-pdf')['outputDirectory'] || ''; 
+
+    if (outputDirectory.length === 0 || outputDirectory === '.') {
       return filename;
     }
 
-    // Use a home directory relative path If it starts with ~.
-    if (outputDirectory.indexOf('~') === 0) {
-      outputDir = outputDirectory.replace(/^~/, os.homedir());
-      mkdir(outputDir);
-      return path.join(outputDir, path.basename(filename));
-    }
+    let outputDir;
 
-    // Use path if it is absolute
+
     if (path.isAbsolute(outputDirectory)) {
-      if (!isExistsDir(outputDirectory)) {
-        showErrorMessage(`The output directory specified by the markdown-pdf.outputDirectory option does not exist.\
-          Check the markdown-pdf.outputDirectory option. ` + outputDirectory);
-        return;
-      }
-      return path.join(outputDirectory, path.basename(filename));
+      outputDir = outputDirectory;
+    } else if (outputDirectory[0] === "~") {
+      outputDir = outputDirectory.replace(/^~/, os.homedir());
+    } else if (outputDirectory[0] === ".") {
+      outputDir = path.join(vscode.workspace.rootPath, outputDirectory)
+    } else {
+      showErrorMessage(`The output directory specified by the markdown-pdf.outputDirectory option is invalid.`)
+      return;
     }
 
-    // Use a workspace relative path if there is a workspace and markdown-pdf.outputDirectoryRootPath = workspace
-    var outputDirectoryRelativePathFile = vscode.workspace.getConfiguration('markdown-pdf')['outputDirectoryRelativePathFile'];
-    let root = vscode.workspace.getWorkspaceFolder(resource);
-    if (outputDirectoryRelativePathFile === false && root) {
-      outputDir = path.join(root.uri.fsPath, outputDirectory);
-      mkdir(outputDir);
-      return path.join(outputDir, path.basename(filename));
-    }
-
-    // Otherwise look relative to the markdown file
-    outputDir = path.join(path.dirname(resource.fsPath), outputDirectory);
+    const workspaceRootPath = vscode.workspace.rootPath;
+    const resourcePath = path.parse(resource.fsPath);
+    const relativePathDir = resourcePath.dir.replace(workspaceRootPath, '');
+    outputDir = path.join(outputDir, relativePathDir);
     mkdir(outputDir);
     return path.join(outputDir, path.basename(filename));
   } catch (error) {


### PR DESCRIPTION
currently, all the files are stored under outputDirectory without any folder structure even though the original workspace has different folder structure.

The example is my workspace path is `/home/vincent178/notes`, the markdown is under `/home/vincent178/notes/works/javascript.md`, the `outputDirectory` is `/home/vincent178/google`, 
The generated pdf is under `/home/vincent178/google/javascript.pdf` instead of `/home/vincent178/google/work/javascript.pdf`.

My PR is to enhance the `getOutputDir` function to support this ability. 