### PR TITLE
Integrate markdown-it-include plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Supports the following features
 * [emoji](http://www.webpagefx.com/tools/emoji-cheat-sheet/)
 * [markdown-it-checkbox](https://github.com/mcecot/markdown-it-checkbox)
 * [markdown-it-container](https://github.com/markdown-it/markdown-it-container)
+* [markdown-it-include](https://github.com/camelaissani/markdown-it-include)
 * [PlantUML](http://plantuml.com/)
   * [markdown-it-plantuml](https://github.com/gmunguia/markdown-it-plantuml)
 
@@ -72,6 +73,34 @@ OUTPUT
 
 ![PlantUML](images/PlantUML.png)
 
+### markdown-it-include
+
+Include markdown fragment files: `:[alternate-text](relative-path-to-file.md)`.
+
+```
+├── [plugins]
+│  └── README.md
+├── CHANGELOG.md
+└── README.md
+```
+
+INPUT
+```
+README Content
+
+:[Plugins](./plugins/README.md)
+
+:[Changelog](CHANGELOG.md)
+```
+
+OUTPUT
+```
+Content of README.md
+
+Content of plugins/README.md
+
+Content of CHANGELOG.md
+```
 
 ## Install
 

--- a/extension.js
+++ b/extension.js
@@ -262,6 +262,15 @@ function convertMarkdownToHtml(filename, type, text) {
   // https://github.com/gmunguia/markdown-it-plantuml
   md.use(require('markdown-it-plantuml'));
 
+  // markdown-it-include
+  // https://github.com/camelaissani/markdown-it-include
+  // the syntax is :[alt-text](relative-path-to-file.md)
+  // https://talk.commonmark.org/t/transclusion-or-including-sub-documents-for-reuse/270/13
+  md.use(require("markdown-it-include"), {
+    root: path.dirname(filename),
+    includeRe: /\:(?:\[[^\]]*\])?\(([^)]+\.md)\)/i
+  });
+
   statusbarmessage.dispose();
   return md.render(text);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1846,6 +1846,11 @@
       "resolved": "https://registry.npmjs.org/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz",
       "integrity": "sha1-m+4OmpkKljupbfaYDE/dsF37Tcw="
     },
+    "markdown-it-include": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-include/-/markdown-it-include-1.1.0.tgz",
+      "integrity": "sha512-OeXvJHfEHrnXWH8+eqMeIX0aFJz4W2ULzfbEVGXBEXab7i3cqLWUxtiHUokZ0/A2uZvLXSaFns/BEVN/mINaCQ=="
+    },
     "markdown-it-named-headers": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/markdown-it-named-headers/-/markdown-it-named-headers-0.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -461,6 +461,7 @@
     "markdown-it-checkbox": "^1.1.0",
     "markdown-it-container": "^2.0.0",
     "markdown-it-emoji": "^1.4.0",
+    "markdown-it-include": "^1.1.0",
     "markdown-it-named-headers": "0.0.4",
     "markdown-it-plantuml": "^1.0.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Ability to include content of one markdown file to another for building single PDF from multiple markdown source files. Syntax: `:[alternate-text](relative-path-to-file.md)`. See #86 

#### Example
```
├── [plugins]
│   └── README.md
├── CHANGELOG.md
└── README.md
```

INPUT
```
Content of README.md
:[Plugins](./plugins/README.md)
:[Changelog](CHANGELOG.md)
```

OUTPUT
```
Content of README.md
Content of plugins/README.md
Content of CHANGELOG.md
```