### PR TITLE
Fix: Specifying custom style sheets  with a relative path does not work

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -735,7 +735,7 @@ function fixHref(resource, href) {
     }
 
     // Use href as file URI if it is absolute
-    if (path.isAbsolute(href) || hrefUri.scheme === 'file') {
+    if (path.isAbsolute(href)) {
       return vscode.Uri.file(href).toString();
     }
 


### PR DESCRIPTION
Setting relative paths in markdown-pdf.styles currently (VS Code 1.41.0, Markdown PDF 1.4.1) does not work because the path will always be converted to a absolute path.
For example `styles/custom.css` will become `files:///styles/custom.css`
This makes Markdown PDF fall back to the VS Code default styles.

The reason is, that `hrefUri.scheme === 'file'` is not only true for absolute file paths, but also for relative paths.

This PR fixes this issue.