### PR TITLE
Reduce Regex strictness of markdown-it-include

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -278,7 +278,7 @@ function convertMarkdownToHtml(filename, type, text) {
   if (vscode.workspace.getConfiguration('markdown-pdf')['markdown-it-include']['enable']) {
     md.use(require("markdown-it-include"), {
       root: path.dirname(filename),
-      includeRe: /\:(?:\[[^\]]*\])?\(([^)]+\.md)\)/i
+      includeRe: /\:(?:\[[^\]]*\])?\(([^)]+\.*)\)/i
     });
   }
 


### PR DESCRIPTION
The current regexp only lets you include other *.md files, but it's sometimes handy to be able to include other source files in your pdf for developer docs (such as external json, js, or other source code).

I've relaxed the regex so you can include files with any extension, rather than just .md