### PR TITLE
extend setting 'headerTemplate' with scope...

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -423,7 +423,7 @@ function exportPdf(data, filename, type, uri) {
             path: exportFilename,
             scale: vscode.workspace.getConfiguration('markdown-pdf')['scale'],
             displayHeaderFooter: vscode.workspace.getConfiguration('markdown-pdf')['displayHeaderFooter'],
-            headerTemplate: vscode.workspace.getConfiguration('markdown-pdf')['headerTemplate'] || '',
+            headerTemplate: vscode.workspace.getConfiguration('markdown-pdf', uri)['headerTemplate'] || '',
             footerTemplate: vscode.workspace.getConfiguration('markdown-pdf')['footerTemplate'] || '',
             printBackground: vscode.workspace.getConfiguration('markdown-pdf')['printBackground'],
             landscape: landscape_option,

--- a/package.json
+++ b/package.json
@@ -302,7 +302,8 @@
         "markdown-pdf.headerTemplate": {
           "type": "string",
           "default": "<div style=\"font-size: 9px; margin-left: 1cm;\"> <span class='title'></span></div> <div style=\"font-size: 9px; margin-left: auto; margin-right: 1cm; \"> <span class='date'></span></div>",
-          "description": "pdf only. HTML template for the print header."
+          "description": "pdf only. HTML template for the print header.",
+          "scope": "resource"
         },
         "markdown-pdf.footerTemplate": {
           "type": "string",


### PR DESCRIPTION
*.. scope: "resource" will able to setup separate .vscode/settings.json per workspace folder*

with this small change single options can be set on workspace-folder level.
An example: The following FOLDER structure
```
project_root
├── sub1
│   └── sub1.md
├── sub2
│   ├── sub2.md
│   └── .vscode
│       └── settings.json
├── root.md
└── .vscode
    └── settings.json
```
With a simple workspace (only one root), the settings of `project_root/.vscode/settings.json` will be used for all Markdown files. (if `markdown-pdf.headerTemplate` isn't set, Userlevel settings or Default settings will be used). 
At this point, same behaviour as now.

**But** when you add `project_root/sub2` as separate folder to the workspace:
* the settings of `project_root/sub2/.vscode/settings.json` will be used for `project_root/sub2/sub2.md`.
* For `project_root/root.md` the settings from `project_root/.vscode/settings.json` will be used.
* For `project_root/sub1/sub1.md` the Userlevel/default settings will be used, as long as you haven't set separate workspace level settings (inside the `.code-workspace` file for the loaded workspace)

> in that pull request, I only changed `headerTemplate` because currently this is the only option that I need. but you could also change the/some other options, to made them individual set able on [workspace-root](https://code.visualstudio.com/docs/editor/multi-root-workspaces) level!

**This could maybe also a solution for #173**
***
## Extended Example
`project_root/.vscode/settings.json`
```json
{
  "markdown-pdf.headerTemplate": "<div style=\"font-size: 9px; margin-left: 1cm;\">project_root level Header</div>"
}
```
`project_root/.vscode/ws.code-workspace`
```json
{
  "folders": [
    {
      "path": "../"
    },
    {
      "path": "../sub1"
    },
    {
      "path": "../sub2"
    }
  ],
  "settings": {
    "markdown-pdf.headerTemplate": "<div style=\"font-size: 9px; margin-left: 1cm;\">workspace level Header</div>"
  }
}
```
`project_root/sub2/.vscode/settings.json`
```json
{
  "markdown-pdf.headerTemplate": "<div style=\"font-size: 9px; margin-left: 1cm;\">sub2 individual Header</div>"
}
```
![workspace](https://user-images.githubusercontent.com/24607675/76459234-19801200-63dc-11ea-860b-b9ab0be931cb.png)
![root](https://user-images.githubusercontent.com/24607675/76459253-20a72000-63dc-11ea-9448-14d6a09fc024.png)
![sub1](https://user-images.githubusercontent.com/24607675/76459257-23097a00-63dc-11ea-8ea8-d35b0223c233.png)
![sub2](https://user-images.githubusercontent.com/24607675/76459259-24d33d80-63dc-11ea-810b-f1519fccb7d1.png)

