### PR TITLE
Support different date formats in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,9 @@ If the download is not successful or you want to avoid downloading every time yo
   - `<span class='url'></span>` : markdown full path name
   - `<span class='pageNumber'></span>` : current page number
   - `<span class='totalPages'></span>` : total pages in the document
+  - `%%ISO-DATETIME%%` : current date and time in ISO-based format (`YYYY-MM-DD hh:mm:ss`)
+  - `%%ISO-DATE%%` : current date in ISO-based format (`YYYY-MM-DD`)
+  - `%%ISO-TIME%%` : current time in ISO-based format (`hh:mm:ss`)
 
 ```javascript
 "markdown-pdf.headerTemplate": "<div style=\"font-size: 9px; margin-left: 1cm;\"> <span class='title'></span></div> <div style=\"font-size: 9px; margin-left: auto; margin-right: 1cm; \"> <span class='date'></span></div>",

--- a/extension.js
+++ b/extension.js
@@ -426,8 +426,8 @@ function exportPdf(data, filename, type, uri) {
             path: exportFilename,
             scale: vscode.workspace.getConfiguration('markdown-pdf', uri)['scale'],
             displayHeaderFooter: vscode.workspace.getConfiguration('markdown-pdf', uri)['displayHeaderFooter'],
-            headerTemplate: vscode.workspace.getConfiguration('markdown-pdf', uri)['headerTemplate'] || '',
-            footerTemplate: vscode.workspace.getConfiguration('markdown-pdf', uri)['footerTemplate'] || '',
+            headerTemplate: transformTemplate(vscode.workspace.getConfiguration('markdown-pdf', uri)['headerTemplate'] || ''),
+            footerTemplate: transformTemplate(vscode.workspace.getConfiguration('markdown-pdf', uri)['footerTemplate'] || ''),
             printBackground: vscode.workspace.getConfiguration('markdown-pdf', uri)['printBackground'],
             landscape: landscape_option,
             pageRanges: vscode.workspace.getConfiguration('markdown-pdf', uri)['pageRanges'] || '',
@@ -502,6 +502,27 @@ function exportPdf(data, filename, type, uri) {
       }
     } // async
   ); // vscode.window.withProgress
+}
+
+/**
+ * Transform the text of the header or footer template, replacing the following supported placeholders:
+ *
+ * - `%%ISO-DATETIME%%` – For an ISO-based date and time format: `YYYY-MM-DD hh:mm:ss`
+ * - `%%ISO-DATE%%` – For an ISO-based date format: `YYYY-MM-DD`
+ * - `%%ISO-TIME%%` – For an ISO-based time format: `hh:mm:ss`
+ */
+function transformTemplate(templateText) {
+  if (templateText.indexOf('%%ISO-DATETIME%%') !== -1) {
+    templateText = templateText.replace('%%ISO-DATETIME%%', new Date().toISOString().substr(0, 19).replace('T', ' '));
+  }
+  if (templateText.indexOf('%%ISO-DATE%%') !== -1) {
+    templateText = templateText.replace('%%ISO-DATE%%', new Date().toISOString().substr(0, 10));
+  }
+  if (templateText.indexOf('%%ISO-TIME%%') !== -1) {
+    templateText = templateText.replace('%%ISO-TIME%%', new Date().toISOString().substr(11, 8));
+  }
+
+  return templateText;
 }
 
 function isExistsPath(path) {


### PR DESCRIPTION
This already came up before in #74 and #95 but I am not happy with leaving this to the locale default format. My VS Code is also in a different locale (English) than the format I would have wanted to use (German).

So I came up with a different way that allows transformations to be applied on the header and footer templates before they are passed to puppeteer. That way, one can skip the `<span class="date"></span>` part and just use placeholders that are replaced directly.

The supported placeholders for now are:

- `%%ISO-DATETIME%%` – For an ISO-based date and time format: `YYYY-MM-DD hh:mm:ss`
- `%%ISO-DATE%%` – For an ISO-based date format: `YYYY-MM-DD`
- `%%ISO-TIME%%` – For an ISO-based time format: `hh:mm:ss`

I originally wanted to allow for completely custom formats but that would require some additional dependencies to format dates properly as one shouldn’t reinvent that.

With these placeholder, I can now simply configure my header template like this:

```
"markdown-pdf.headerTemplate": "<div style=\"font-size: 9px; margin-left: 1cm;\"> <span class='title'></span></div> <div style=\"font-size: 9px; margin-left: auto; margin-right: 1cm; \">%%ISO-DATE%%</div>"
```