### PR TITLE
Add MathJax

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Supports the following features
 * [markdown-it-checkbox](https://github.com/mcecot/markdown-it-checkbox)
 * [markdown-it-container](https://github.com/markdown-it/markdown-it-container)
 * [markdown-it-include](https://github.com/camelaissani/markdown-it-include)
+* [markdown-it-mathjax3](https://github.com/nzt/markdown-it-mathjax3)
 * [PlantUML](https://plantuml.com/)
   * [markdown-it-plantuml](https://github.com/gmunguia/markdown-it-plantuml)
 * [mermaid](https://mermaid-js.github.io/mermaid/)
@@ -620,6 +621,7 @@ MIT
 * [markdown-it/markdown-it-container](https://github.com/markdown-it/markdown-it-container)
 * [gmunguia/markdown-it-plantuml](https://github.com/gmunguia/markdown-it-plantuml)
 * [camelaissani/markdown-it-include](https://github.com/camelaissani/markdown-it-include)
+* [markdown-it-mathjax3](https://github.com/nzt/markdown-it-mathjax3/)
 * [mermaid-js/mermaid](https://github.com/mermaid-js/mermaid)
 * [jonschlinkert/gray-matter](https://github.com/jonschlinkert/gray-matter)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Supports the following features
 * [markdown-it-checkbox](https://github.com/mcecot/markdown-it-checkbox)
 * [markdown-it-container](https://github.com/markdown-it/markdown-it-container)
 * [markdown-it-include](https://github.com/camelaissani/markdown-it-include)
-* [markdown-it-mathjax3](https://github.com//markdown-it-mathjax3)
+* [markdown-it-mathjax3](https://github.com/tani/markdown-it-mathjax3)
 * [PlantUML](https://plantuml.com/)
   * [markdown-it-plantuml](https://github.com/gmunguia/markdown-it-plantuml)
 * [mermaid](https://mermaid-js.github.io/mermaid/)
@@ -621,7 +621,7 @@ MIT
 * [markdown-it/markdown-it-container](https://github.com/markdown-it/markdown-it-container)
 * [gmunguia/markdown-it-plantuml](https://github.com/gmunguia/markdown-it-plantuml)
 * [camelaissani/markdown-it-include](https://github.com/camelaissani/markdown-it-include)
-* [markdown-it-mathjax3](https://github.com/nzt/markdown-it-mathjax3/)
+* [markdown-it-mathjax3](https://github.com/tani/markdown-it-mathjax3/)
 * [mermaid-js/mermaid](https://github.com/mermaid-js/mermaid)
 * [jonschlinkert/gray-matter](https://github.com/jonschlinkert/gray-matter)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Supports the following features
 * [markdown-it-checkbox](https://github.com/mcecot/markdown-it-checkbox)
 * [markdown-it-container](https://github.com/markdown-it/markdown-it-container)
 * [markdown-it-include](https://github.com/camelaissani/markdown-it-include)
-* [markdown-it-mathjax3](https://github.com/nzt/markdown-it-mathjax3)
+* [markdown-it-mathjax3](https://github.com//markdown-it-mathjax3)
 * [PlantUML](https://plantuml.com/)
   * [markdown-it-plantuml](https://github.com/gmunguia/markdown-it-plantuml)
 * [mermaid](https://mermaid-js.github.io/mermaid/)

--- a/extension.js
+++ b/extension.js
@@ -216,6 +216,9 @@ function convertMarkdownToHtml(filename, type, text) {
     };
   }
 
+  // mathjax
+  md.use(require('markdown-it-mathjax3'));
+
   // checkbox
   md.use(require('markdown-it-checkbox'));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,11 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -822,6 +827,11 @@
         "source-map": "~0.6.1"
       }
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+    },
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -854,14 +864,14 @@
       }
     },
     "extract-zip": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+      "integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
       "requires": {
-        "concat-stream": "1.6.2",
-        "debug": "2.6.9",
-        "mkdirp": "0.5.1",
-        "yauzl": "2.4.1"
+        "concat-stream": "^1.6.2",
+        "debug": "^2.6.9",
+        "mkdirp": "^0.5.4",
+        "yauzl": "^2.10.0"
       },
       "dependencies": {
         "debug": {
@@ -872,17 +882,12 @@
             "ms": "2.0.0"
           }
         },
-        "minimist": {
-          "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
-        },
         "mkdirp": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "requires": {
-            "minimist": "0.0.8"
+            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -917,9 +922,9 @@
       "optional": true
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "requires": {
         "pend": "~1.2.0"
       }
@@ -1452,6 +1457,14 @@
       "resolved": "https://registry.npmjs.org/markdown-it-include/-/markdown-it-include-1.1.0.tgz",
       "integrity": "sha512-OeXvJHfEHrnXWH8+eqMeIX0aFJz4W2ULzfbEVGXBEXab7i3cqLWUxtiHUokZ0/A2uZvLXSaFns/BEVN/mINaCQ=="
     },
+    "markdown-it-mathjax3": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-mathjax3/-/markdown-it-mathjax3-2.2.0.tgz",
+      "integrity": "sha512-Y2G00QXod4lgaOflwvKW89PTEi8mqDD0Ew1Qczpo0Du91HxCYvCAdflpYaKv0d/IdJk6ilbZC35vVqyT7ahZVg==",
+      "requires": {
+        "mathjax-full": "^3.0.5"
+      }
+    },
     "markdown-it-named-headers": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/markdown-it-named-headers/-/markdown-it-named-headers-0.0.4.tgz",
@@ -1464,6 +1477,16 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/markdown-it-plantuml/-/markdown-it-plantuml-1.4.1.tgz",
       "integrity": "sha512-13KgnZaGYTHBp4iUmGofzZSBz+Zj6cyqfR0SXUIc9wgWTto5Xhn7NjaXYxY0z7uBeTUMlc9LMQq5uP4OM5xCHg=="
+    },
+    "mathjax-full": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.0.5.tgz",
+      "integrity": "sha512-RzZ03DDMOgqeHPl3dkqDVS3bmXU+lfZZimj7+k3VA+s93LbZcOAKa2hlILF3rgBXgzGLR3YOR8Z8R/B3uAeAeA==",
+      "requires": {
+        "esm": "^3.2.25",
+        "mj-context-menu": "^0.2.2",
+        "speech-rule-engine": "^3.0.0-beta.10"
+      }
     },
     "mdurl": {
       "version": "1.0.1",
@@ -1499,8 +1522,12 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+    },
+    "mj-context-menu": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.2.2.tgz",
+      "integrity": "sha512-OHlnKQqfFPEYZGdz2JWL0obrr82vVilha0WCUZslYfN+v+oz4VpmERnoHdTUWvOUVHNYjFkpOYnLEeHnt1BdsQ=="
     },
     "mkdirp": {
       "version": "1.0.3",
@@ -1921,6 +1948,16 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "optional": true
     },
+    "speech-rule-engine": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-3.0.1.tgz",
+      "integrity": "sha512-07B/V6eKZQfoKHdw8QaRu3ENKwbE8XcgCFNJAGeKnz751TixF6xUmxqLnsAN4zIj0qUCUKxCy4/LHybBMBmNfQ==",
+      "requires": {
+        "commander": "*",
+        "wicked-good-xpath": "*",
+        "xmldom-sre": "^0.1.31"
+      }
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2184,6 +2221,11 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha1-gbDpXoZQ5JyUsiKY//hoa1VTz2w="
+    },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -2256,6 +2298,11 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
       "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
       "optional": true
+    },
+    "xmldom-sre": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom-sre/-/xmldom-sre-0.1.31.tgz",
+      "integrity": "sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw=="
     },
     "xmlhttprequest": {
       "version": "1.8.0",
@@ -2336,11 +2383,12 @@
       }
     },
     "yauzl": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "requires": {
-        "fd-slicer": "~1.0.1"
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -500,6 +500,7 @@
     "markdown-it-container": "^2.0.0",
     "markdown-it-emoji": "^1.4.0",
     "markdown-it-include": "^1.1.0",
+    "markdown-it-mathjax3": "^2.2.0",
     "markdown-it-named-headers": "0.0.4",
     "markdown-it-plantuml": "^1.4.1",
     "mkdirp": "^1.0.3",


### PR DESCRIPTION
closes #17 #36 #167 #168 ;

 Hi there, I am author of the following plugins

MathJaX v3 plugin of VNote https://github.com/tamlok/vnote/pull/1221
MathJaX v3 plugin of Remark https://github.com/remarkjs/remark-math/pull/40
MathJaX v3 plugin of Markdown-It https://github.com/nzt/markdown-it-mathjax3
MathJaX v3 plugin of Marp https://github.com/marp-team/marp-core/issues/164

I  propose to use markdown-it-mathjax3 plugin to close above issues.
This plugin runs completely to render SVG without any external internet connection,
Compared to other pull request, this plugin customizes Markdown-parser. So, there are no conflicts against other markdown syntax. 