### PR TITLE
Fix description of outputDirectoryRelativePathFile

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
         "markdown-pdf.outputDirectoryRelativePathFile": {
           "type": "boolean",
           "default": false,
-          "description": "If markdown-pdf.outputDirectoryRelativePathFile option is set to true, the relative path set with markdown-pdf.styles is interpreted as relative from the file"
+          "description": "If markdown-pdf.outputDirectoryRelativePathFile option is set to true, the relative path set with markdown-pdf.outputDirectory is interpreted as relative from the file"
         },
         "markdown-pdf.styles": {
           "type": "array",


### PR DESCRIPTION
`outputDirectoryRelativePathFile` changes the interpretation of `markdown-pdf.outputDirectory`, instead of the mentioned `markdown-pdf.styles`