### PR TITLE
Avoid TimeoutError: Navigation timeout of 30000 ms exceeded and TimeoutError: waiting for Page.printToPDF failed: timeout 30000ms exceeded

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -404,6 +404,7 @@ function exportPdf(data, filename, type, uri) {
       };
         const browser = await puppeteer.launch(options);
         const page = await browser.newPage();
+        await page.setDefaultNavigationTimeout(0);
         await page.goto(vscode.Uri.file(tmpfilename).toString(), { waitUntil: 'networkidle0' });
         // generate pdf
         // https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions

--- a/extension.js
+++ b/extension.js
@@ -404,7 +404,7 @@ function exportPdf(data, filename, type, uri) {
       };
         const browser = await puppeteer.launch(options);
         const page = await browser.newPage();
-        await page.setDefaultNavigationTimeout(0);
+        await page.setDefaultTimeout(0);
         await page.goto(vscode.Uri.file(tmpfilename).toString(), { waitUntil: 'networkidle0' });
         // generate pdf
         // https://github.com/GoogleChrome/puppeteer/blob/master/docs/api.md#pagepdfoptions
@@ -440,8 +440,9 @@ function exportPdf(data, filename, type, uri) {
               right: vscode.workspace.getConfiguration('markdown-pdf', uri)['margin']['right'] || '',
               bottom: vscode.workspace.getConfiguration('markdown-pdf', uri)['margin']['bottom'] || '',
               left: vscode.workspace.getConfiguration('markdown-pdf', uri)['margin']['left'] || ''
-            }
-          }
+            },
+            timeout: 0
+          };
           await page.pdf(options);
         }
 


### PR DESCRIPTION
私の MacBook Air 2012 で 2 万行くらいの Markdown を Google Chrome 95.0.4638.69（Official Build） （x86_64） で pdf 出力しようとすると、10 分くらいかかってしまい、タイトルのエラーが発生します😰
これを回避するためタイムアウトが発生しにようにしました。

---

When I try to output 20,000 lines of Markdown to pdf using Google Chrome 95.0.4638.69 (Official Build) (x86_64) on my MacBook Air 2012, it takes about 10 minutes and I get the error in the title 😰.
In order to avoid this, I made sure that the timeout does not occur.