### PR TITLE
Fix #210

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -396,9 +396,14 @@ function exportPdf(data, filename, type, uri) {
         var f = path.parse(filename);
         var tmpfilename = path.join(f.dir, f.name + '_tmp.html');
         exportHtml(data, tmpfilename);
+        
+        var customEnv = process.env;
+        customEnv.LANG = vscode.env.language; 
+        
         var options = {
           executablePath: vscode.workspace.getConfiguration('markdown-pdf')['executablePath'] || puppeteer.executablePath(),
-          args: ['--lang='+vscode.env.language, '--no-sandbox', '--disable-setuid-sandbox']
+          args: ['--lang='+vscode.env.language, '--no-sandbox', '--disable-setuid-sandbox'],
+          env: customEnv
           // Setting Up Chrome Linux Sandbox
           // https://github.com/puppeteer/puppeteer/blob/master/docs/troubleshooting.md#setting-up-chrome-linux-sandbox
       };


### PR DESCRIPTION
The lang argument to chromium via puppeteer is broken. A working solution is to provide the same language option as part of the browser environment. Detailed explanation is here: https://github.com/yzane/vscode-markdown-pdf/issues/210#issuecomment-971726106