### PR TITLE
Update: change mermaid script tag to type="module"

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -332,7 +332,7 @@ function makeHtml(data, uri) {
 
     // read mermaid javascripts
     var mermaidServer = vscode.workspace.getConfiguration('markdown-pdf')['mermaidServer'] || '';
-    var mermaid = '<script src=\"' + mermaidServer + '\"></script>';
+    var mermaid = '<script type="module" src=\"' + mermaidServer + '\"></script>';
 
     // compile template
     var mustache = require('mustache');


### PR DESCRIPTION
#342 

In the latest mermaid (v11)

The official document has changed to 

```html
<html>
  <body>
    Here is one mermaid diagram:
    <pre class="mermaid">
            graph TD
            A[Client] --> B[Load Balancer]
            B --> C[Server1]
            B --> D[Server2]
    </pre>

    And here is another:
    <pre class="mermaid">
            graph TD
            A[Client] -->|tcp_123| B
            B(Load Balancer)
            B -->|tcp_456| C[Server1]
            B -->|tcp_456| D[Server2]
    </pre>

    <script type="module">
      import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
      mermaid.initialize({ startOnLoad: true });
    </script>
  </body>
</html>
```

The `type="module"` is required to get a proper import.


