### PR TITLE
doc: updated README file to add a note for installation on ARM Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ If you are behind a proxy, set the `http.proxy` option to settings.json and rest
 
 If the download is not successful or you want to avoid downloading every time you upgrade Markdown PDF, please specify the installed [Chrome](https://www.google.co.jp/chrome/) or 'Chromium' with [markdown-pdf.executablePath](#markdown-pdfexecutablepath) option.
 
+<strong>Note (ARM Macs)</strong>: Puppeteer v2.1.1 downloads an older x86_64 Chromium build. On Apple Silicon, ensure that you have Rosetta or set `markdown-pdf.executablePath` to a native Chromium binary installation.
+
 <div class="page"/>
 
 ## Usage


### PR DESCRIPTION
# Description

Added a note for installation on ARM Macs.

# What Does This PR Do?

The extension uses Puppeteer v2.1.1, which uses an older x86_64 build of Chromium. Since this isn't natively supported by ARM Macs, there is a note specifying the requirement of Rosetta if they choose to use the bundled Chromium binary. Alternatively, users can configure `markdown-pdf.executablePath` to point to a locally installed native Chromium binary.