### PR TITLE
Add stylesInline option to embed user CSS as inline <style> tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,6 +180,11 @@
           "default": false,
           "description": "If markdown-pdf.stylesRelativePathFile option is set to true, the relative path set with markdown-pdf.styles is interpreted as relative from the file"
         },
+        "markdown-pdf.stylesInline": {
+          "type": "boolean",
+          "default": false,
+          "description": "If set to true, embed the contents of markdown-pdf.styles as inline <style> tags instead of <link> references. Useful when opening HTML output on a different OS (e.g. WSL to Windows)."
+        },
         "markdown-pdf.includeDefaultStyles": {
           "type": "boolean",
           "default": true,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -475,6 +475,7 @@ function readStyles(uri: vscode.Uri): string | undefined {
     const highlight = vscode.workspace.getConfiguration('markdown-pdf')['highlight'];
     const markdownStyles = vscode.workspace.getConfiguration('markdown')['styles'] || [];
     const markdownPdfStyles = vscode.workspace.getConfiguration('markdown-pdf')['styles'] || '';
+    const stylesInline = vscode.workspace.getConfiguration('markdown-pdf')['stylesInline'] || false;
 
     return utils.buildStyleTags({
       includeDefaultStyles: includeDefaultStyles,
@@ -482,6 +483,7 @@ function readStyles(uri: vscode.Uri): string | undefined {
       highlightStyle: highlightStyle,
       markdownStyles: markdownStyles,
       markdownPdfStyles: markdownPdfStyles,
+      stylesInline: stylesInline,
       baseDir: EXTENSION_ROOT,
       onMissingHighlightStyle: function (requestedStyle: string, resolvedStyle: string) {
         vscode.window.showWarningMessage(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -248,6 +248,7 @@ interface BuildStyleTagsOptions {
   highlightStyle: string;
   markdownStyles: string[] | string;
   markdownPdfStyles: string[] | string;
+  stylesInline?: boolean;
   baseDir: string;
   onMissingHighlightStyle?: (requestedStyle: string, resolvedStyle: string) => void;
   resolveHrefFn: (href: string) => string;
@@ -293,8 +294,12 @@ export function buildStyleTags(options: BuildStyleTagsOptions): string {
 
   if (options.markdownPdfStyles && Array.isArray(options.markdownPdfStyles) && options.markdownPdfStyles.length > 0) {
     for (let i = 0; i < options.markdownPdfStyles.length; i++) {
-      const markdownPdfHref = options.resolveHrefFn(options.markdownPdfStyles[i]);
-      style += '<link rel="stylesheet" href="' + markdownPdfHref + '" type="text/css">';
+      if (options.stylesInline) {
+        style += makeCss(options.markdownPdfStyles[i]);
+      } else {
+        const markdownPdfHref = options.resolveHrefFn(options.markdownPdfStyles[i]);
+        style += '<link rel="stylesheet" href="' + markdownPdfHref + '" type="text/css">';
+      }
     }
   }
 

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -798,6 +798,45 @@ describe('utils', function () {
       assert.ok(result.indexOf('file:///resolved/style.css') === -1, 'Expected no link tag for string markdownStyles');
     });
 
+    it('should embed markdownPdfStyles as inline style tags when stylesInline is true', function () {
+      const fs = require('fs');
+      const path = require('path');
+      const tmpCss = path.join(baseDir, 'test', 'unit', '_tmp_inline_test.css');
+      fs.writeFileSync(tmpCss, 'body { color: red; }');
+      try {
+        const result = utils.buildStyleTags({
+          includeDefaultStyles: false,
+          highlight: false,
+          highlightStyle: '',
+          markdownStyles: [],
+          markdownPdfStyles: [tmpCss],
+          stylesInline: true,
+          baseDir: baseDir,
+          resolveHrefFn: function (href: string) { return 'file:///resolved/' + href; },
+        });
+        assert.ok(result.indexOf('<style>') !== -1, 'Expected <style> tag');
+        assert.ok(result.indexOf('body { color: red; }') !== -1, 'Expected inline CSS content');
+        assert.ok(result.indexOf('<link') === -1, 'Expected no <link> tag');
+      } finally {
+        fs.unlinkSync(tmpCss);
+      }
+    });
+
+    it('should use link tags for markdownPdfStyles when stylesInline is false', function () {
+      const result = utils.buildStyleTags({
+        includeDefaultStyles: false,
+        highlight: false,
+        highlightStyle: '',
+        markdownStyles: [],
+        markdownPdfStyles: ['custom.css'],
+        stylesInline: false,
+        baseDir: baseDir,
+        resolveHrefFn: function (href: string) { return 'file:///resolved/' + href; },
+      });
+      assert.ok(result.indexOf('<link rel="stylesheet"') !== -1, 'Expected <link> tag');
+      assert.ok(result.indexOf('file:///resolved/custom.css') !== -1, 'Expected resolved href');
+    });
+
     it('should skip markdownPdfStyles when value is a string instead of array', function () {
       const result = utils.buildStyleTags({
         includeDefaultStyles: false,


### PR DESCRIPTION
## Summary

When `markdown-pdf.stylesInline` is set to `true`, user-specified CSS files (`markdown-pdf.styles`) are embedded as inline `<style>` tags instead of `<link>` references in the HTML output.

### Problem

When generating HTML in a WSL environment and opening it in a Windows browser, the `file:///home/...` paths in `<link>` tags cannot be resolved. This makes user-specified CSS effectively invisible in the HTML output, even though it works fine for PDF output (where Puppeteer can access local files).

### Solution

- Added a new boolean setting `markdown-pdf.stylesInline` (default: `false`)
- When enabled, reuses the existing `makeCss()` function to read CSS file contents and wrap them in `<style>` tags
- No change in behavior when disabled — fully backward compatible

### Usage

```json
{
  "markdown-pdf.styles": ["/path/to/custom.css"],
  "markdown-pdf.stylesInline": true
}
```

All existing unit tests pass (282 tests, 0 failures).

> Note: This addresses the same use case as #319, updated for the v2.0.0 TypeScript codebase with unit tests.