### PR TITLE
fix: stop markdown-it-include from duplicating content across fenced blocks

### DIFF
--- a/src/markdown-it-include.ts
+++ b/src/markdown-it-include.ts
@@ -58,67 +58,85 @@ function findCodeRegions(src: string): CodeRegion[] {
     }
   }
 
-  // Pass 2: find inline code (backtick sequences) outside fenced blocks
+  // Fence regions are discovered above in a single left-to-right pass, so they
+  // are already sorted by start position at this point.
+  const fenceRegions = regions.slice();
+
+  function fenceRegionAt(index: number): CodeRegion | undefined {
+    return fenceRegions.find((r) => index >= r.start && index < r.end);
+  }
+
+  // A blank line (a `\n`, only whitespace, then another `\n`) always ends a
+  // paragraph in Markdown, and an inline code span cannot cross that boundary
+  // — same as it cannot cross into a fenced code block. `nextParagraphBreak`
+  // finds the earliest such boundary at or after `from`.
+  const blankLineRe = /\n[ \t]*\n/g;
+  function nextParagraphBreak(from: number): number {
+    blankLineRe.lastIndex = from;
+    const m = blankLineRe.exec(src);
+    return m ? m.index : src.length;
+  }
+
+  // Pass 2: find inline code spans outside fenced blocks, following the same
+  // "backtick string" rule CommonMark/markdown-it use: a run of N backticks
+  // opens a code span, which is closed by the *next* run of exactly N
+  // backticks *within the same paragraph*. Runs of a different length
+  // encountered while searching for the closer are just content — they are
+  // never reinterpreted as a fresh opener mid-search. Crucially, hitting a
+  // fenced block or a blank line while searching ends the search as "no
+  // closer found" rather than skipping past it: a fence or a blank line is a
+  // block-level boundary a code span can never cross, so treating them as
+  // something to leapfrog over is what previously let an opener latch onto
+  // an unrelated, much later backtick and swallow everything — fenced blocks
+  // included — into one bogus region.
   let pos = 0;
   while (pos < src.length) {
-    const tickIdx = src.indexOf('`', pos);
-    if (tickIdx === -1) break;
-
-    // Skip if inside a fenced code block
-    if (regions.some((r) => tickIdx >= r.start && tickIdx < r.end)) {
-      pos = regions.find((r) => tickIdx >= r.start && tickIdx < r.end)!.end;
+    const fenceHere = fenceRegionAt(pos);
+    if (fenceHere) {
+      pos = fenceHere.end;
       continue;
     }
 
-    // Count consecutive backticks
-    let tickCount = 0;
-    let tickEnd = tickIdx;
-    while (tickEnd < src.length && src[tickEnd] === '`') {
-      tickCount++;
-      tickEnd++;
-    }
-
-    // If this is 3+ backticks at line start, it was already handled as fenced block
-    if (tickCount >= 3 && (tickIdx === 0 || src[tickIdx - 1] === '\n')) {
-      pos = tickEnd;
+    if (src[pos] !== '`') {
+      pos += 1;
       continue;
     }
 
-    // Find matching closing backtick sequence (exact count)
-    const closingTicks = '`'.repeat(tickCount);
-    let searchFrom = tickEnd;
-    let closingIdx = -1;
-    while (searchFrom < src.length) {
-      const candidate = src.indexOf(closingTicks, searchFrom);
-      if (candidate === -1) break;
+    let openEnd = pos;
+    while (openEnd < src.length && src[openEnd] === '`') openEnd++;
+    const openLen = openEnd - pos;
+    const searchLimit = nextParagraphBreak(openEnd);
 
-      // Verify exact match: not followed by another backtick
-      if (candidate + tickCount < src.length && src[candidate + tickCount] === '`') {
-        searchFrom = candidate + 1;
+    let searchPos = openEnd;
+    let closeStart = -1;
+    while (searchPos < searchLimit) {
+      const fenceAhead = fenceRegionAt(searchPos);
+      if (fenceAhead) break;
+      if (src[searchPos] !== '`') {
+        searchPos += 1;
         continue;
       }
-      // Not preceded by a backtick (beyond our opening sequence)
-      if (candidate > tickEnd && candidate > 0 && src[candidate - 1] === '`') {
-        searchFrom = candidate + 1;
-        continue;
+      let candEnd = searchPos;
+      while (candEnd < src.length && src[candEnd] === '`') candEnd++;
+      if (candEnd - searchPos === openLen) {
+        closeStart = searchPos;
+        break;
       }
-
-      // Skip if inside a fenced code block
-      if (regions.some((r) => candidate >= r.start && candidate < r.end)) {
-        searchFrom = regions.find((r) => candidate >= r.start && candidate < r.end)!.end;
-        continue;
-      }
-
-      closingIdx = candidate;
-      break;
+      // Different-length run: not our closer. Per CommonMark this run is
+      // ordinary content for the span we're still looking to close, so skip
+      // past it and keep searching — do not treat it as a new opener here.
+      searchPos = candEnd;
     }
 
-    if (closingIdx !== -1) {
-      const end = closingIdx + tickCount;
-      regions.push({ start: tickIdx, end });
-      pos = end;
+    if (closeStart === -1) {
+      // No closer within this paragraph: this backtick run is literal text,
+      // not a delimiter. Resume scanning right after it so any later,
+      // genuinely-paired span is still found on its own.
+      pos = openEnd;
     } else {
-      pos = tickEnd;
+      const end = closeStart + openLen;
+      regions.push({ start: pos, end });
+      pos = end;
     }
   }
 

--- a/test/unit/markdown-it-include.test.ts
+++ b/test/unit/markdown-it-include.test.ts
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { describe, it, before, after } from 'node:test';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { markdownItInclude } from '../../src/markdown-it-include';
+
+// markdownItInclude only registers a markdown-it core rule; it doesn't need a
+// real MarkdownIt instance to exercise, so a minimal stub with the one method
+// it calls is enough and keeps these tests fast and dependency-free.
+function expand(src: string, root: string): string {
+  let coreRule: ((state: { src: string }) => void) | undefined;
+  const fakeMd = {
+    core: {
+      ruler: {
+        before: (_anchor: string, _name: string, rule: (state: { src: string }) => void) => {
+          coreRule = rule;
+        },
+      },
+    },
+  };
+  markdownItInclude(fakeMd as any, { root, throwError: false });
+  const state = { src };
+  coreRule!(state);
+  return state.src;
+}
+
+describe('markdownItInclude', () => {
+  let tmpDir: string;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'markdown-pdf-include-'));
+    fs.writeFileSync(path.join(tmpDir, 'part.md'), 'Included content.');
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('expands a legitimate :[alt](path) directive', () => {
+    const out = expand('Before.\n\n:[alt](part.md)\n\nAfter.', tmpDir);
+    assert.equal(out, 'Before.\n\nIncluded content.\n\nAfter.');
+  });
+
+  it('reports a missing include target instead of throwing', () => {
+    const out = expand(':[alt](missing.md)', tmpDir);
+    assert.match(out, /INCLUDE ERROR: File .* not found\./);
+  });
+
+  it('does not expand include syntax inside inline code', () => {
+    const src = 'Text `:[alt](part.md)` more text.';
+    assert.equal(expand(src, tmpDir), src);
+  });
+
+  it('does not expand include syntax inside a fenced code block', () => {
+    const src = 'Text.\n\n```\n:[alt](part.md)\n```\n\nMore text.';
+    assert.equal(expand(src, tmpDir), src);
+  });
+
+  it('still protects a code span that spans multiple lines within one paragraph', () => {
+    const src = 'Some `code\nspanning :[a](part.md) two lines` end.';
+    assert.equal(expand(src, tmpDir), src);
+  });
+
+  it('does not protect include syntax across a blank line (different paragraph)', () => {
+    // A single backtick run can't open a code span that reaches past a blank
+    // line, so this is *not* inline code — the include directive on the
+    // second paragraph is expected to expand normally.
+    const src = 'Stray ` backtick.\n\n:[alt](part.md)';
+    const out = expand(src, tmpDir);
+    assert.equal(out, 'Stray ` backtick.\n\nIncluded content.');
+  });
+
+  // Regression test for a real-world bug: on documents with enough inline
+  // code spans, an unmatched/odd backtick run could pair with a backtick
+  // several paragraphs later, treating everything in between — including a
+  // fenced code block — as "inline code" content. `replaceIncludes` then
+  // reconstructed the document with that swallowed region appended a second
+  // time as raw text, silently duplicating a chunk of the document in the
+  // rendered output. See the fenced block that sits between the stray
+  // backtick and the later, unrelated code span below: a correct scanner
+  // must fail to find a closer for the stray backtick (it's on the other
+  // side of a fence, which a code span can never cross) instead of matching
+  // it against `` `ok` ``.
+  it('does not let a stray backtick swallow a later fenced block and duplicate content', () => {
+    const src = 'Text with a stray `backtick here.\n\n```txt\n```\n\nLater text with `ok`.';
+    assert.equal(expand(src, tmpDir), src);
+  });
+});


### PR DESCRIPTION
Fixes #443

## Problem

On documents with enough single-backtick inline code spans, `findCodeRegions()` (used by the `markdown-it-include` core rule to protect code from `:[alt](path)` expansion) could pair an opening backtick with a closing backtick several paragraphs later — skipping straight over anything in between, including a real fenced code block. `replaceIncludes()` then reconstructed the source with that swallowed span emitted a second time as raw, unrendered text, silently duplicating a chunk of the document in the exported PDF/HTML. This runs on every export by default (`markdown-pdf.markdown-it-include.enable` defaults to `true`), even when the document has no `:[...](...)` include directive at all.

Full root-cause writeup and the original 790-line reproduction are in #443.

## Fix

A code span can never cross a fenced code block or a blank line (paragraph break) — that's true both in CommonMark and in how this plugin is meant to protect content. The closer search in `findCodeRegions()` now **stops** at either boundary instead of skipping past it, and treats the opening backtick run as literal text when no closer is found before hitting one. This is the same "backtick string" matching rule CommonMark/markdown-it use, just scoped correctly to a single paragraph.

## Testing

- `npm run check` — clean.
- `npm run test:unit` — all pre-existing tests still pass (18 unrelated pre-existing failures, network/Chromium-dependent, unaffected by this change).
- Added `test/unit/markdown-it-include.test.ts` (7 cases): legitimate includes still expand, include syntax inside inline/fenced code stays protected, multi-line code spans within one paragraph stay protected, and a minimal regression case (found via automated delta-debugging on the original 790-line real-world reproduction) that fails on the pre-fix code and passes with this change.
- Re-ran the fix against the real-world document that originally surfaced this (anonymized version attached to #443): output is now byte-identical to input, no duplication.
