### PR TITLE
Exposed pupeteers PDFOption `outline` config

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -395,6 +395,7 @@ Markdown PDF は PDF/PNG/JPEG エクスポートに Chromium ベースのブラ�
 ||[markdown-pdf.clip.width](#markdown-pdfclipwidth)| |
 ||[markdown-pdf.clip.height](#markdown-pdfclipheight)| |
 ||[markdown-pdf.omitBackground](#markdown-pdfomitbackground)| |
+||[markdown-pdf.outline](#markdown-pdfoutline)| |
 |[PlantUML options](#plantuml-options)|[markdown-pdf.plantumlOpenMarker](#markdown-pdfplantumlopenmarker)| |
 ||[markdown-pdf.plantumlCloseMarker](#markdown-pdfplantumlclosemarker)| |
 ||[markdown-pdf.plantumlServer](#markdown-pdfplantumlserver)| |
@@ -711,6 +712,11 @@ Markdown PDF は PDF/PNG/JPEG エクスポートに Chromium ベースのブラ�
 
 #### `markdown-pdf.omitBackground`
   - デフォルトの白い背景ではなく、透過によるスクリーンショットのキャプチャーを有効にします
+  - boolean. Default: false
+
+#### `markdown-pdf.outline`
+  - PDF ドキュメントのアウトラインを生成します。これは Puppeteer の PDFOptions インターフェイスにおける実験的機能であり、すべてのケースで正常に動作することは保証されていません。
+
   - boolean. Default: false
 
 ### PlantUML options

--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ To collect environment information for a bug report, run `Markdown PDF: Output D
 ||[markdown-pdf.clip.width](#markdown-pdfclipwidth)| |
 ||[markdown-pdf.clip.height](#markdown-pdfclipheight)| |
 ||[markdown-pdf.omitBackground](#markdown-pdfomitbackground)| |
+||[markdown-pdf.outline](#markdown-pdfoutline)| |
 |[PlantUML options](#plantuml-options)|[markdown-pdf.plantumlOpenMarker](#markdown-pdfplantumlopenmarker)| |
 ||[markdown-pdf.plantumlCloseMarker](#markdown-pdfplantumlclosemarker)| |
 ||[markdown-pdf.plantumlServer](#markdown-pdfplantumlserver)| |
@@ -714,6 +715,10 @@ To collect environment information for a bug report, run `Markdown PDF: Output D
 
 #### `markdown-pdf.omitBackground`
   - Hides default white background and allows capturing screenshots with transparency
+  - boolean. Default: false
+
+#### `markdown-pdf.outline`
+  - Generates the PDF document outline. This is an experimental pupeteer PDFOptions interface feature and it not guaranteed to work in all cases.
   - boolean. Default: false
 
 ### PlantUML options

--- a/package.json
+++ b/package.json
@@ -894,6 +894,11 @@
           "default": false,
           "description": "png and jpeg only. Hides default white background and allows capturing screenshots with transparency."
         },
+        "markdown-pdf.outline": {
+          "type": "boolean",
+          "default": false,
+          "description": "Generate PDF document outline. NOTE: This is an experimental pupeteer PDFOptions Interface feature."
+        },
         "markdown-pdf.plantumlOpenMarker": {
           "type": "string",
           "default": "@startuml",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -599,6 +599,7 @@ function exportPdf(
             footerTemplate: vscode.workspace.getConfiguration('markdown-pdf', uri)['footerTemplate'] || '',
             printBackground: vscode.workspace.getConfiguration('markdown-pdf', uri)['printBackground'],
             pageRanges: vscode.workspace.getConfiguration('markdown-pdf', uri)['pageRanges'] || '',
+            outline: vscode.workspace.getConfiguration('markdown-pdf', uri)['outline'],
             margin: {
               top: vscode.workspace.getConfiguration('markdown-pdf', uri)['margin']['top'] || '',
               right: vscode.workspace.getConfiguration('markdown-pdf', uri)['margin']['right'] || '',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -363,6 +363,7 @@ interface PdfConfig {
   footerTemplate: string;
   printBackground: boolean;
   pageRanges: string;
+  outline: boolean;
   margin: { top: string; right: string; bottom: string; left: string };
 }
 
@@ -386,6 +387,7 @@ export function buildPdfOptions(config: PdfConfig): Record<string, unknown> {
     width: config.width,
     height: config.height,
     margin: config.margin,
+    outline: config.outline,
     timeout: 0,
   };
 }

--- a/test/unit/utils.test.ts
+++ b/test/unit/utils.test.ts
@@ -866,6 +866,7 @@ describe('utils', function () {
         headerTemplate: '',
         footerTemplate: '',
         printBackground: true,
+        outline: false,
         pageRanges: '',
         margin: { top: '', right: '', bottom: '', left: '' },
       });
@@ -886,6 +887,7 @@ describe('utils', function () {
         headerTemplate: '',
         footerTemplate: '',
         printBackground: true,
+        outline: false,
         pageRanges: '',
         margin: { top: '', right: '', bottom: '', left: '' },
       });
@@ -905,6 +907,7 @@ describe('utils', function () {
         headerTemplate: '',
         footerTemplate: '',
         printBackground: true,
+        outline: false,
         pageRanges: '',
         margin: { top: '', right: '', bottom: '', left: '' },
       });
@@ -924,6 +927,7 @@ describe('utils', function () {
         headerTemplate: '',
         footerTemplate: '',
         printBackground: true,
+        outline: false,
         pageRanges: '',
         margin: { top: '', right: '', bottom: '', left: '' },
       });
@@ -942,6 +946,7 @@ describe('utils', function () {
         headerTemplate: '',
         footerTemplate: '',
         printBackground: true,
+        outline: false,
         pageRanges: '',
         margin: { top: '', right: '', bottom: '', left: '' },
       });
@@ -960,6 +965,7 @@ describe('utils', function () {
         headerTemplate: '%%ISO-DATE%%',
         footerTemplate: '%%ISO-TIME%%',
         printBackground: true,
+        outline: false,
         pageRanges: '',
         margin: { top: '', right: '', bottom: '', left: '' },
       });
@@ -1279,6 +1285,7 @@ describe('utils', function () {
         headerTemplate: '',
         footerTemplate: '',
         printBackground: true,
+        outline: false,
         pageRanges: '',
         margin: margin,
       });
@@ -1297,6 +1304,7 @@ describe('utils', function () {
         headerTemplate: '',
         footerTemplate: '',
         printBackground: true,
+        outline: false,
         pageRanges: '',
         margin: { top: '', right: '', bottom: '', left: '' },
       });


### PR DESCRIPTION
Added a configuration option to the available markdown-pdf settings which allows a user to set pupeteers PDFOption Interface `outline` boolean configuration to include an outline of the markdown document's sections.

## Code Changes

The `PdfConfig` interface was updated to include the `outline` boolean option which would be pulled from the corresponding `markdown-pdf.outline` configuration. The configuration description, type, and default value was added to the `package.json`.

The value for this option defaults to `false` due to pupeteers outline option still being experimental.

## Documentation Changes

Both the English and Japanese README files were updated with the information on the new configuration. However, the Japanese description in `README.ja.md` was generated through the use of AI. As I do not speak Japanese, I did my due diligence to ensure the translation is properly representative of the English version, __but__ it still needs to be reviewed for correctness.

## Test Changes

Tests which provide a configuration were updated to have the `outline` value included as required by the updated interface definition. Otherwise, there were no test categories or test suites which were relevant to this change, so __no additional tests were created__.

## Review

`npm run check` and `npm run test` were run and completed successfully.